### PR TITLE
Create unique tmpdir to avoid sharing state

### DIFF
--- a/bagit.go
+++ b/bagit.go
@@ -88,21 +88,13 @@ func (b *BagIt) Validate(path string) error {
 
 	reader := bufio.NewReader(stdout)
 
-	args := args{
+	if err := b.sendCommand(stdin, args{
 		Cmd: "validate",
 		Opts: &opts{
 			Path: path,
 		},
-	}
-	blob, err := json.Marshal(args)
-	if err != nil {
-		return fmt.Errorf("encode args: %v", err)
-	}
-	blob = append(blob, '\n')
-
-	_, err = stdin.Write(blob)
-	if err != nil {
-		return fmt.Errorf("write blob: %v", err)
+	}); err != nil {
+		return err
 	}
 
 	line := bytes.NewBuffer(nil)
@@ -135,6 +127,21 @@ func (b *BagIt) Validate(path string) error {
 	}
 	if !r.Valid {
 		return fmt.Errorf("invalid: %s", r.Err)
+	}
+
+	return nil
+}
+
+func (b *BagIt) sendCommand(stdin io.Writer, args args) error {
+	blob, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("encode args: %v", err)
+	}
+	blob = append(blob, '\n')
+
+	_, err = stdin.Write(blob)
+	if err != nil {
+		return fmt.Errorf("write blob: %v", err)
 	}
 
 	return nil

--- a/bagit.go
+++ b/bagit.go
@@ -81,6 +81,10 @@ func (b *BagIt) Validate(path string) error {
 	if err != nil {
 		return fmt.Errorf("cmd: %v", err)
 	}
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
 
 	reader := bufio.NewReader(stdout)
 

--- a/bagit.go
+++ b/bagit.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/artefactual-labs/bagit-gython/internal/dist/data"
 	"github.com/artefactual-labs/bagit-gython/internal/runner"
@@ -17,32 +16,41 @@ import (
 	"github.com/kluctl/go-embed-python/python"
 )
 
+// BagIt is an abstraction to work with BagIt packages that embeds Python and
+// the bagit-python.
 type BagIt struct {
-	ep     *python.EmbeddedPython
-	lib    *embed_util.EmbeddedFiles
-	runner *embed_util.EmbeddedFiles
-	mu     sync.Mutex
+	tmpDir string                    // Top-level container for embedded files.
+	ep     *python.EmbeddedPython    // Python files.
+	lib    *embed_util.EmbeddedFiles // bagit-python library files.
+	runner *embed_util.EmbeddedFiles // bagit-python wrapper files (runner).
 }
 
+// NewBagIt creates and initializes a new BagIt instance. This constructor is
+// computationally expensive as it sets up an embedded Python environment and
+// extracts necessary libraries. It's recommended to create a single instance
+// and share it across your application to avoid repeatedly installing Python.
 func NewBagIt() (*BagIt, error) {
 	b := &BagIt{}
 
-	tmpDir := filepath.Join(os.TempDir(), "python")
-	tmpDir = filepath.Join(tmpDir, "bagit")
+	var err error
+	b.tmpDir, err = os.MkdirTemp("", "bagit-gython-*")
+	if err != nil {
+		return nil, fmt.Errorf("make tmpDir: %v", err)
+	}
 
-	ep, err := python.NewEmbeddedPythonWithTmpDir(tmpDir, true)
+	ep, err := python.NewEmbeddedPythonWithTmpDir(filepath.Join(b.tmpDir, "python"), true)
 	if err != nil {
 		return nil, fmt.Errorf("embed python: %v", err)
 	}
 	b.ep = ep
 
-	b.lib, err = embed_util.NewEmbeddedFilesWithTmpDir(data.Data, tmpDir+"-bagit-lib", true)
+	b.lib, err = embed_util.NewEmbeddedFilesWithTmpDir(data.Data, filepath.Join(b.tmpDir, "bagit-lib"), true)
 	if err != nil {
 		return nil, fmt.Errorf("embed bagit: %v", err)
 	}
 	b.ep.AddPythonPath(b.lib.GetExtractedPath())
 
-	b.runner, err = embed_util.NewEmbeddedFilesWithTmpDir(runner.Source, tmpDir+"-runner", true)
+	b.runner, err = embed_util.NewEmbeddedFilesWithTmpDir(runner.Source, filepath.Join(b.tmpDir, "bagit-runner"), true)
 	if err != nil {
 		return nil, fmt.Errorf("embed runner: %v", err)
 	}
@@ -51,9 +59,6 @@ func NewBagIt() (*BagIt, error) {
 }
 
 func (b *BagIt) Validate(path string) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	cmd, err := b.ep.PythonCmd(filepath.Join(b.runner.GetExtractedPath(), "main.py"))
 	if err != nil {
 		return fmt.Errorf("create command: %v", err)
@@ -134,16 +139,20 @@ func (b *BagIt) Validate(path string) error {
 func (b *BagIt) Cleanup() error {
 	var e error
 
-	if err := b.ep.Cleanup(); err != nil {
-		e = errors.Join(e, fmt.Errorf("clean up python: %v", err))
+	if err := b.runner.Cleanup(); err != nil {
+		e = errors.Join(e, fmt.Errorf("clean up runner: %v", err))
 	}
 
 	if err := b.lib.Cleanup(); err != nil {
 		e = errors.Join(e, fmt.Errorf("clean up bagit: %v", err))
 	}
 
-	if err := b.runner.Cleanup(); err != nil {
-		e = errors.Join(e, fmt.Errorf("clean up runner: %v", err))
+	if err := b.ep.Cleanup(); err != nil {
+		e = errors.Join(e, fmt.Errorf("clean up python: %v", err))
+	}
+
+	if err := os.RemoveAll(b.tmpDir); err != nil {
+		e = errors.Join(e, fmt.Errorf("clean up tmpDir: %v", err))
 	}
 
 	return e

--- a/bagit_test.go
+++ b/bagit_test.go
@@ -4,20 +4,57 @@ import (
 	"testing"
 
 	"github.com/artefactual-labs/bagit-gython"
+	"golang.org/x/sync/errgroup"
 
 	"gotest.tools/v3/assert"
 )
 
-func TestBagit(t *testing.T) {
-	b, err := bagit.NewBagIt()
-	assert.NilError(t, err)
+func TestValidateBag(t *testing.T) {
+	t.Parallel()
 
-	err = b.Validate("/tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333")
-	assert.Error(t, err, "invalid: Expected bagit.txt does not exist: /tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333/bagit.txt")
+	t.Run("Fails validation", func(t *testing.T) {
+		t.Parallel()
 
-	err = b.Validate("internal/testdata/valid-bag")
-	assert.NilError(t, err)
+		b, err := bagit.NewBagIt()
+		assert.NilError(t, err)
 
-	err = b.Cleanup()
-	assert.NilError(t, err)
+		err = b.Validate("/tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333")
+		assert.Error(t, err, "invalid: Expected bagit.txt does not exist: /tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333/bagit.txt")
+
+		err = b.Cleanup()
+		assert.NilError(t, err)
+	})
+
+	t.Run("Validates bag", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := bagit.NewBagIt()
+		assert.NilError(t, err)
+
+		err = b.Validate("internal/testdata/valid-bag")
+		assert.NilError(t, err)
+
+		err = b.Cleanup()
+		assert.NilError(t, err)
+	})
+
+	t.Run("Validates bag concurrently", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := bagit.NewBagIt()
+		assert.NilError(t, err)
+		t.Cleanup(func() { b.Cleanup() })
+
+		// This test should pass because each call to Validate() creates its own
+		// distinct Python interpreter instance.
+		var g errgroup.Group
+		for i := 0; i < 10; i++ {
+			g.Go(func() error {
+				return b.Validate("internal/testdata/valid-bag")
+			})
+		}
+
+		err = g.Wait()
+		assert.NilError(t, err)
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/kluctl/go-embed-python v0.0.0-3.12.3-20240415-1
+	golang.org/x/sync v0.7.0
 	gotest.tools/v3 v3.5.1
 )
 
@@ -12,6 +13,5 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 )


### PR DESCRIPTION
This pull request ensures that no state is shared between concurrent instances of bagit-gython.

Fixes https://github.com/artefactual-labs/bagit-gython/issues/3.