### PR TITLE
Persist Python interpreter for repeated use

### DIFF
--- a/bagit.go
+++ b/bagit.go
@@ -13,10 +13,18 @@ import (
 	"github.com/kluctl/go-embed-python/python"
 )
 
-// ErrInvalid indicates that bag validation failed. If there is a validation
-// error message, ErrInvalid will be wrapped so make sure to use
-// `errors.Is(err, ErrInvalid)` to test equivalency.
-var ErrInvalid = errors.New("invalid")
+var (
+	// ErrInvalid indicates that bag validation failed. If there is a validation
+	// error message, ErrInvalid will be wrapped so make sure to use
+	// `errors.Is(err, ErrInvalid)` to test equivalency.
+	ErrInvalid = errors.New("invalid")
+
+	// ErrBusy is returned when an operation is attempted on BagIt while it is
+	// already processing another command. This ensures that only one command is
+	// processed at a time, preventing race conditions and ensuring the
+	// integrity of the shared resources.
+	ErrBusy = errors.New("runner is busy")
+)
 
 // BagIt is an abstraction to work with BagIt packages that embeds Python and
 // the bagit-python.

--- a/bagit.go
+++ b/bagit.go
@@ -25,7 +25,7 @@ type BagIt struct {
 	embedPython *python.EmbeddedPython    // Python files.
 	embedBagit  *embed_util.EmbeddedFiles // bagit-python library files.
 	embedRunner *embed_util.EmbeddedFiles // bagit-python wrapper files (runner).
-	runner      *runnerInstance
+	runner      *pyRunner
 }
 
 // NewBagIt creates and initializes a new BagIt instance. This constructor is

--- a/bagit.go
+++ b/bagit.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/artefactual-labs/bagit-gython/internal/dist/data"
@@ -62,36 +61,6 @@ func NewBagIt() (*BagIt, error) {
 	}
 
 	return b, nil
-}
-
-// create a Python intepreter running the bagit-python wrapper.
-func (b *BagIt) create() (*runnerInstance, error) {
-	i := &runnerInstance{}
-
-	cmd, err := b.embedPython.PythonCmd(filepath.Join(b.embedRunner.GetExtractedPath(), "main.py"))
-	if err != nil {
-		return nil, fmt.Errorf("create command: %v", err)
-	}
-	i.cmd = cmd
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create stdin pipe: %v", err)
-	}
-	i.stdin = stdin
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create stdout pipe: %v", err)
-	}
-	i.stdout = stdout
-
-	err = cmd.Start()
-	if err != nil {
-		return nil, fmt.Errorf("cmd: %v", err)
-	}
-
-	return i, nil
 }
 
 type validateRequest struct {
@@ -224,57 +193,6 @@ func (b *BagIt) Cleanup() error {
 
 	if err := os.RemoveAll(b.tmpDir); err != nil {
 		e = errors.Join(e, fmt.Errorf("clean up tmpDir: %v", err))
-	}
-
-	return e
-}
-
-type args struct {
-	Cmd  string `json:"cmd"`
-	Opts any    `json:"opts"`
-}
-
-// runnerInstance is an instance of a Python interpreter executing the
-// bagit-python runner.
-type runnerInstance struct {
-	cmd    *exec.Cmd
-	stdin  io.WriteCloser
-	stdout io.ReadCloser
-}
-
-// send a command to the runner.
-func (i *runnerInstance) send(args args) error {
-	blob, err := json.Marshal(args)
-	if err != nil {
-		return fmt.Errorf("encode args: %v", err)
-	}
-	blob = append(blob, '\n')
-
-	_, err = i.stdin.Write(blob)
-	if err != nil {
-		return fmt.Errorf("write blob: %v", err)
-	}
-
-	return nil
-}
-
-func (i *runnerInstance) stop() error {
-	var e error
-
-	if err := i.stdin.Close(); err != nil {
-		e = errors.Join(e, err)
-	}
-
-	if err := i.stdout.Close(); err != nil {
-		e = errors.Join(e, err)
-	}
-
-	if err := i.cmd.Process.Kill(); err != nil {
-		e = errors.Join(e, err)
-	}
-
-	if _, err := i.cmd.Process.Wait(); err != nil {
-		e = errors.Join(e, err)
 	}
 
 	return e

--- a/bagit.go
+++ b/bagit.go
@@ -75,11 +75,8 @@ type validateResponse struct {
 }
 
 func (b *BagIt) Validate(path string) error {
-	blob, err := b.runner.send(args{
-		Cmd: "validate",
-		Opts: &validateRequest{
-			Path: path,
-		},
+	blob, err := b.runner.send("validate", &validateRequest{
+		Path: path,
 	})
 	if err != nil {
 		return err
@@ -110,11 +107,8 @@ type makeResponse struct {
 }
 
 func (b *BagIt) Make(path string) error {
-	blob, err := b.runner.send(args{
-		Cmd: "make",
-		Opts: &makeRequest{
-			Path: path,
-		},
+	blob, err := b.runner.send("make", &makeRequest{
+		Path: path,
 	})
 	if err != nil {
 		return err

--- a/bagit_test.go
+++ b/bagit_test.go
@@ -24,18 +24,8 @@ func setUp(t *testing.T) *bagit.BagIt {
 	return b
 }
 
-func TestValidateBag(t *testing.T) {
+func TestConcurrency(t *testing.T) {
 	t.Parallel()
-
-	t.Run("Fails validation", func(t *testing.T) {
-		t.Parallel()
-
-		b := setUp(t)
-
-		err := b.Validate("/tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333")
-		assert.Error(t, err, "invalid: Expected bagit.txt does not exist: /tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333/bagit.txt")
-		assert.Assert(t, errors.Is(err, bagit.ErrInvalid))
-	})
 
 	t.Run("Validates bag", func(t *testing.T) {
 		t.Parallel()
@@ -79,6 +69,33 @@ func TestValidateBag(t *testing.T) {
 		err := g.Wait()
 		assert.NilError(t, err)
 	})
+}
+
+func TestValidateBag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Fails validation", func(t *testing.T) {
+		t.Parallel()
+
+		b := setUp(t)
+
+		err := b.Validate("/tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333")
+		assert.Error(t, err, "invalid: Expected bagit.txt does not exist: /tmp/691b8e7f-e6b7-41dd-bc47-868e2ff69333/bagit.txt")
+		assert.Assert(t, errors.Is(err, bagit.ErrInvalid))
+	})
+
+	t.Run("Validates bag", func(t *testing.T) {
+		t.Parallel()
+
+		b := setUp(t)
+
+		err := b.Validate("internal/testdata/valid-bag")
+		assert.NilError(t, err)
+	})
+}
+
+func TestMakeBag(t *testing.T) {
+	t.Parallel()
 
 	t.Run("Creates bag", func(t *testing.T) {
 		t.Parallel()

--- a/bagit_test.go
+++ b/bagit_test.go
@@ -11,17 +11,27 @@ import (
 	"gotest.tools/v3/fs"
 )
 
-func setUp(t *testing.T) *bagit.BagIt {
-	t.Helper()
+func setUp(tb testing.TB) *bagit.BagIt {
+	tb.Helper()
 
 	b, err := bagit.NewBagIt()
-	assert.NilError(t, err)
+	assert.NilError(tb, err)
 
-	t.Cleanup(func() {
-		assert.NilError(t, b.Cleanup())
+	tb.Cleanup(func() {
+		assert.NilError(tb, b.Cleanup())
 	})
 
 	return b
+}
+
+func BenchmarkValidate(b *testing.B) {
+	bagit := setUp(b)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = bagit.Validate("internal/testdata/valid-bag")
+	}
 }
 
 func TestConcurrency(t *testing.T) {

--- a/internal/runner/main.py
+++ b/internal/runner/main.py
@@ -11,21 +11,21 @@ class Runner:
         self.req = req
 
     @property
-    def cmd(self):
-        return self.req.get("cmd")
+    def name(self):
+        return self.req.get("name")
 
     @property
-    def opts(self):
-        return self.req.get("opts")
+    def args(self):
+        return self.req.get("args")
 
     def run(self):
         resp = {}
 
         try:
-            if self.cmd == "validate":
-                resp = self.validate(self.opts)
-            elif self.cmd == "make":
-                resp = self.make(self.opts)
+            if self.name == "validate":
+                resp = self.validate(self.args)
+            elif self.name == "make":
+                resp = self.make(self.args)
             else:
                 raise Exception("Unknown command")
         except BaseException as err:
@@ -33,14 +33,14 @@ class Runner:
 
         return json.dumps(resp)
 
-    def validate(self, opts):
-        bag = Bag(opts.get("path"))
+    def validate(self, args):
+        bag = Bag(args.get("path"))
         bag.validate(processes=multiprocessing.cpu_count())
         return {"valid": True}
 
-    def make(self, opts):
-        bag_dir = opts.pop("path")
-        bag = make_bag(bag_dir, **opts)
+    def make(self, args):
+        bag_dir = args.pop("path")
+        bag = make_bag(bag_dir, **args)
         return {"version": bag.version}
 
 
@@ -51,7 +51,7 @@ def main():
             break
 
         req = json.loads(cmd)
-        if req.get("cmd") == "exit":
+        if req.get("name") == "exit":
             break
 
         result = Runner(req).run()

--- a/runner.go
+++ b/runner.go
@@ -1,42 +1,79 @@
 package bagit
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os/exec"
-	"path/filepath"
+	"sync"
+
+	"github.com/kluctl/go-embed-python/python"
 )
 
-// create a Python intepreter running the bagit-python wrapper.
-func (b *BagIt) create() (*runnerInstance, error) {
-	i := &runnerInstance{}
+var ErrBusy = errors.New("runner is busy")
 
-	cmd, err := b.embedPython.PythonCmd(filepath.Join(b.embedRunner.GetExtractedPath(), "main.py"))
-	if err != nil {
-		return nil, fmt.Errorf("create command: %v", err)
+// runnerInstance is an instance of a Python interpreter executing the
+// bagit-python runner.
+type runnerInstance struct {
+	py           *python.EmbeddedPython
+	entryPoint   string
+	cmd          *exec.Cmd
+	stdin        io.WriteCloser
+	stdout       io.ReadCloser
+	stdoutReader *bufio.Reader
+	mu           sync.Mutex
+}
+
+func createRunner(py *python.EmbeddedPython, entryPoint string) *runnerInstance {
+	return &runnerInstance{
+		py:         py,
+		entryPoint: entryPoint,
 	}
-	i.cmd = cmd
+}
 
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create stdin pipe: %v", err)
-	}
-	i.stdin = stdin
-
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("create stdout pipe: %v", err)
-	}
-	i.stdout = stdout
-
-	err = cmd.Start()
-	if err != nil {
-		return nil, fmt.Errorf("cmd: %v", err)
+// exited determines whether the process has exited.
+func (r *runnerInstance) exited() bool {
+	if r.cmd == nil || r.cmd.ProcessState == nil {
+		return true
 	}
 
-	return i, nil
+	return r.cmd.ProcessState.Exited()
+}
+
+// ensure that the process is running.
+func (r *runnerInstance) ensure() error {
+	if !r.exited() {
+		return nil
+	}
+
+	var err error
+	r.cmd, err = r.py.PythonCmd(r.entryPoint)
+	if err != nil {
+		return fmt.Errorf("start runner: %v", err)
+	}
+
+	// r.cmd.Stderr = os.Stderr
+
+	r.stdin, err = r.cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("create stdin pipe: %v", err)
+	}
+
+	r.stdout, err = r.cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("create stdout pipe: %v", err)
+	}
+	r.stdoutReader = bufio.NewReader(r.stdout)
+
+	err = r.cmd.Start()
+	if err != nil {
+		return fmt.Errorf("start cmd: %v", err)
+	}
+
+	return nil
 }
 
 type args struct {
@@ -44,32 +81,66 @@ type args struct {
 	Opts any    `json:"opts"`
 }
 
-// runnerInstance is an instance of a Python interpreter executing the
-// bagit-python runner.
-type runnerInstance struct {
-	cmd    *exec.Cmd
-	stdin  io.WriteCloser
-	stdout io.ReadCloser
-}
-
 // send a command to the runner.
-func (i *runnerInstance) send(args args) error {
+func (i *runnerInstance) send(args args) ([]byte, error) {
+	if ok := i.mu.TryLock(); !ok {
+		return nil, ErrBusy
+	}
+	defer i.mu.Unlock()
+
+	if err := i.ensure(); err != nil {
+		return nil, err
+	}
+
 	blob, err := json.Marshal(args)
 	if err != nil {
-		return fmt.Errorf("encode args: %v", err)
+		return nil, fmt.Errorf("encode args: %v", err)
 	}
 	blob = append(blob, '\n')
 
 	_, err = i.stdin.Write(blob)
 	if err != nil {
-		return fmt.Errorf("write blob: %v", err)
+		return nil, fmt.Errorf("write blob: %v", err)
 	}
 
-	return nil
+	line := bytes.NewBuffer(nil)
+	for {
+		l, p, err := i.stdoutReader.ReadLine()
+		if err != nil && err != io.EOF {
+			return nil, fmt.Errorf("read line: %v", err)
+		}
+		line.Write(l)
+		if !p {
+			break
+		}
+	}
+	if line.Len() < 1 {
+		return nil, fmt.Errorf("response not received")
+	}
+
+	return line.Bytes(), nil
+}
+
+// quit requests the runner to exit gracefully.
+func (r *runnerInstance) quit() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.exited() {
+		return nil
+	}
+
+	_, err := r.stdin.Write([]byte(`{"name": "exit"}`))
+
+	return err
 }
 
 func (i *runnerInstance) stop() error {
 	var e error
+
+	if err := i.quit(); err != nil {
+		e = errors.Join(e, err)
+	}
 
 	if err := i.stdin.Close(); err != nil {
 		e = errors.Join(e, err)

--- a/runner.go
+++ b/runner.go
@@ -86,13 +86,13 @@ func (r *pyRunner) ensure() error {
 	return nil
 }
 
-type args struct {
-	Cmd  string `json:"cmd"`
-	Opts any    `json:"opts"`
+type cmd struct {
+	Name string `json:"name"` // Name of the command, e.g.: "validate", "make", etc...
+	Args any    `json:"args"` // Payload, e.g. &validateRequest{}.
 }
 
 // send a command to the runner.
-func (r *pyRunner) send(name string, opts any) ([]byte, error) {
+func (r *pyRunner) send(name string, args any) ([]byte, error) {
 	if ok := r.mu.TryLock(); !ok {
 		return nil, ErrBusy
 	}
@@ -102,7 +102,7 @@ func (r *pyRunner) send(name string, opts any) ([]byte, error) {
 		return nil, err
 	}
 
-	cmd := args{Cmd: name, Opts: opts}
+	cmd := cmd{Name: name, Args: args}
 	blob, err := json.Marshal(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("encode args: %v", err)

--- a/runner.go
+++ b/runner.go
@@ -14,12 +14,6 @@ import (
 	"github.com/kluctl/go-embed-python/python"
 )
 
-// ErrBusy is returned when an operation is attempted on BagIt while it is
-// already processing another command. This ensures that only one command is
-// processed at a time, preventing race conditions and ensuring the integrity
-// of the shared resources.
-var ErrBusy = errors.New("runner is busy")
-
 // pyRunner manages the execution of the Python script wrapping bagit-python.
 // It ensures that only one command is executed at a time and provides
 // mechanisms to send commands and receive responses.

--- a/runner.go
+++ b/runner.go
@@ -1,0 +1,91 @@
+package bagit
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+)
+
+// create a Python intepreter running the bagit-python wrapper.
+func (b *BagIt) create() (*runnerInstance, error) {
+	i := &runnerInstance{}
+
+	cmd, err := b.embedPython.PythonCmd(filepath.Join(b.embedRunner.GetExtractedPath(), "main.py"))
+	if err != nil {
+		return nil, fmt.Errorf("create command: %v", err)
+	}
+	i.cmd = cmd
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create stdin pipe: %v", err)
+	}
+	i.stdin = stdin
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create stdout pipe: %v", err)
+	}
+	i.stdout = stdout
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("cmd: %v", err)
+	}
+
+	return i, nil
+}
+
+type args struct {
+	Cmd  string `json:"cmd"`
+	Opts any    `json:"opts"`
+}
+
+// runnerInstance is an instance of a Python interpreter executing the
+// bagit-python runner.
+type runnerInstance struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+}
+
+// send a command to the runner.
+func (i *runnerInstance) send(args args) error {
+	blob, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("encode args: %v", err)
+	}
+	blob = append(blob, '\n')
+
+	_, err = i.stdin.Write(blob)
+	if err != nil {
+		return fmt.Errorf("write blob: %v", err)
+	}
+
+	return nil
+}
+
+func (i *runnerInstance) stop() error {
+	var e error
+
+	if err := i.stdin.Close(); err != nil {
+		e = errors.Join(e, err)
+	}
+
+	if err := i.stdout.Close(); err != nil {
+		e = errors.Join(e, err)
+	}
+
+	if err := i.cmd.Process.Kill(); err != nil {
+		e = errors.Join(e, err)
+	}
+
+	if _, err := i.cmd.Process.Wait(); err != nil {
+		e = errors.Join(e, err)
+	}
+
+	return e
+}

--- a/runner.go
+++ b/runner.go
@@ -14,6 +14,10 @@ import (
 	"github.com/kluctl/go-embed-python/python"
 )
 
+// ErrBusy is returned when an operation is attempted on BagIt while it is
+// already processing another command. This ensures that only one command is
+// processed at a time, preventing race conditions and ensuring the integrity
+// of the shared resources.
 var ErrBusy = errors.New("runner is busy")
 
 // pyRunner manages the execution of the Python script wrapping bagit-python.

--- a/runner.go
+++ b/runner.go
@@ -92,7 +92,7 @@ type args struct {
 }
 
 // send a command to the runner.
-func (r *pyRunner) send(args args) ([]byte, error) {
+func (r *pyRunner) send(name string, opts any) ([]byte, error) {
 	if ok := r.mu.TryLock(); !ok {
 		return nil, ErrBusy
 	}
@@ -102,7 +102,8 @@ func (r *pyRunner) send(args args) ([]byte, error) {
 		return nil, err
 	}
 
-	blob, err := json.Marshal(args)
+	cmd := args{Cmd: name, Opts: opts}
+	blob, err := json.Marshal(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("encode args: %v", err)
 	}


### PR DESCRIPTION
This PR introduces changes to ensure that the Python interpreter is persisted for repeated use, instead of creating a new instance with each method call. This is a **low priority change**, as it is only beneficial when using `*bagit.BagIt` repeatedly, e.g.: when validating hundreds of bags.

`ErrBusy` is returned if you try to use `*bagit.BagIt` concurrently. If you need to perform concurrent validation you should have a dedicated `*bagit.BagIt` instance per goroutine. Adding support for concurrent work in `*bagit.BagIt` would be possible by implementing an internal pool of interpreters, but this does not seem necessary atm.

Using `-benchtime=10s` shows that the `Validate` method is significantly faster; within 10 seconds, we can now run `Validate` approximately 1,200 times compared to the previous 144 times.

Before:

```
(main) $ go test -run=^BenchmarkValidate -bench=. -benchtime=10s -cpu=1 -count=3
goos: linux
goarch: amd64
pkg: github.com/artefactual-labs/bagit-gython
cpu: Intel(R) Core(TM) i5-8400 CPU @ 2.80GHz
BenchmarkValidate 	     144	  76810063 ns/op
BenchmarkValidate 	     141	  77826339 ns/op
BenchmarkValidate 	     144	  75244650 ns/op
PASS
ok  	github.com/artefactual-labs/bagit-gython	65.955s
```

After:

```
(dev/persistent-branch) $ go test -run=^BenchmarkValidate -bench=. -benchtime=10s -cpu=1 -count=3
goos: linux
goarch: amd64
pkg: github.com/artefactual-labs/bagit-gython
cpu: Intel(R) Core(TM) i5-8400 CPU @ 2.80GHz
BenchmarkValidate 	    1171	   9401249 ns/op
BenchmarkValidate 	    1258	   9371621 ns/op
BenchmarkValidate 	    1255	   9158033 ns/op
PASS
ok  	github.com/artefactual-labs/bagit-gython	84.983s
```

I've made changes to the Python script to improve error handling and reporting. See the following interaction in a terminal where each request (e.g. `INVALID-JSON`) always receives a JSON-encoded request even when malformed, and errors are now including a `type` attribute with the name of the underlying Python exception.

    $ python main.py
    INVALID-JSON
    {"err": "Expecting value: line 1 column 1 (char 0)", "type": "JSONDecodeError"}
    {}
    {"err": "'None' is not a valid command, use: validate, make, exit", "type": "UnknownCommandError"}
    {"name": "validate", "args": {"path": "/etc/motd"}}
    {"err": "Expected bagit.txt does not exist: /etc/motd/bagit.txt", "type": "BagError"}
    {"name": "exit"}
